### PR TITLE
add the symlink changes by fkorotkov

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -17,6 +17,10 @@ func TestArchiver(t *testing.T) {
 			if _, ok := ar.(rarFormat); ok {
 				t.Skip("not supported")
 			}
+			// skip ZIP for now as well since it doesn't support symlinks
+			if _, ok := ar.(zipFormat); ok {
+				t.Skip("not supported")
+			}
 			testWriteRead(t, name, ar)
 			testMakeOpen(t, name, ar)
 		})

--- a/tar.go
+++ b/tar.go
@@ -158,6 +158,12 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 			header.Name += "/"
 		}
 
+		// special handling of symlinks
+		if header.Typeflag == tar.TypeSymlink {
+			linkDest, _ := os.Readlink(path)
+			header.Linkname = linkDest
+		}
+
 		err = tarWriter.WriteHeader(header)
 		if err != nil {
 			return fmt.Errorf("%s: writing header: %v", path, err)

--- a/testdata/symlink/quote1-link.txt
+++ b/testdata/symlink/quote1-link.txt
@@ -1,0 +1,1 @@
+testdata/quote1.txt


### PR DESCRIPTION
These changes remove zip support but allow archiver to work properly with symlinks.

These changes were originally found here and were written by github user fkorotkov: https://github.com/mholt/archiver/pull/40/files